### PR TITLE
Fix: assignment mismatch: 1 variable but c.cron.AddFunc returns 2 values

### DIFF
--- a/grbac.go
+++ b/grbac.go
@@ -201,7 +201,7 @@ func (c *Controller) runCronTab() {
         return
     }
     interval := fmt.Sprintf("@every %ds", int(c.loadInterval.Seconds()))
-    _ = c.cron.AddFunc(interval, func() {
+    _, _ = c.cron.AddFunc(interval, func() {
         c.logger.Debugln("grbac loader is scheduled")
         err := c.reload()
         if err != nil {


### PR DESCRIPTION
Issue:
# github.com/storyicon/grbac
../github.com/storyicon/grbac/grbac.go:204:7: assignment mismatch: 1 variable but c.cron.AddFunc returns 2 values